### PR TITLE
fix: correct favicon paths and author config

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -39,8 +39,7 @@ summaryLength = 30
   ShowShareButtons = false
   dateFormat = "2006-01-02"
   mainSections = ["posts"]
-  [params.author]
-    name = "Brock B"
+  author = "Brock B"
 
   [params.assets]
     favicon = "/blog/favicon.svg"


### PR DESCRIPTION
## Summary
- Fix favicon paths to include `/blog/` subpath prefix and add PNG fallbacks
- Fix author config to use a plain string instead of a TOML map table, which caused PaperMod to render `map[name:Brock B]` on the site

## Test plan
- [ ] Verify favicons load correctly on the deployed site
- [ ] Verify author name displays as "Brock B" (not `map[name:Brock B]`)
- [ ] Verify RSS feed still includes author name

🤖 Generated with [Claude Code](https://claude.com/claude-code)