### PR TITLE
Fix PaperMod search + nav links, add search shortcuts

### DIFF
--- a/content/search.md
+++ b/content/search.md
@@ -1,0 +1,6 @@
+---
+title: "Search"
+layout: "search"
+placeholder: "Search posts..."
+summaryLength: 70
+---

--- a/hugo.toml
+++ b/hugo.toml
@@ -50,7 +50,7 @@ summaryLength = 30
   [params.profileMode]
     enabled = true
     title = "Brock B"
-    subtitle = "A tech enthusiast learning through writing with a primary focus on Data, Cloud, and DevOps"
+    subtitle = "A tech enthusiast learning through writing with a primary focus on Data, AI, Cloud, and DevOps"
 
     [[params.profileMode.buttons]]
       name = "Posts"

--- a/hugo.toml
+++ b/hugo.toml
@@ -83,6 +83,11 @@ summaryLength = 30
   url = "/tags/"
   weight = 3
 
+[[menus.main]]
+  name = "Search"
+  url = "/search/"
+  weight = 4
+
 [sitemap]
   changefreq = "weekly"
   filename = "sitemap.xml"

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -1,0 +1,41 @@
+{{- /* Global keyboard shortcut: open search with "/" or Cmd/Ctrl+K from any page. */ -}}
+{{- with site.GetPage "/search" }}
+<script>
+(function () {
+    var searchURL = {{ .RelPermalink }};
+
+    function isEditable(el) {
+        if (!el) return false;
+        var tag = el.tagName;
+        return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
+    }
+
+    function onSearchPage() {
+        return window.location.pathname.replace(/\/+$/, "") === searchURL.replace(/\/+$/, "");
+    }
+
+    function openSearch() {
+        if (onSearchPage()) {
+            var input = document.getElementById("searchInput");
+            if (input) input.focus();
+        } else {
+            window.location.href = searchURL;
+        }
+    }
+
+    document.addEventListener("keydown", function (e) {
+        // Cmd+K (mac) / Ctrl+K (others)
+        if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+            e.preventDefault();
+            openSearch();
+            return;
+        }
+        // "/" — but not while typing in a field, and not with modifiers
+        if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey && !isEditable(e.target)) {
+            e.preventDefault();
+            openSearch();
+        }
+    });
+})();
+</script>
+{{- end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,110 @@
+<header class="header">
+    <nav class="nav">
+        <div class="logo">
+            {{- $label_text := (site.Params.label.text | default site.Title) }}
+            {{- if site.Title }}
+            <a href="{{ "" | absLangURL }}" accesskey="h" title="{{ $label_text }} (Alt + H)">
+                {{- if site.Params.label.icon }}
+                {{- $img := resources.Get site.Params.label.icon }}
+                {{- if $img }}
+                    {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
+                    {{- if hugo.IsExtended -}}
+                        {{- $processableFormats = $processableFormats | append "webp" -}}
+                    {{- end -}}
+                    {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
+                    {{- if and (in $processableFormats $img.MediaType.SubType) (eq $prod true)}}
+                        {{- if site.Params.label.iconHeight }}
+                            {{- $img = $img.Resize (printf "x%d" site.Params.label.iconHeight) }}
+                        {{ else }}
+                            {{- $img = $img.Resize "x30" }}
+                        {{- end }}
+                    {{- end }}
+                    <img src="{{ $img.Permalink }}" alt="" aria-label="logo"
+                        height="{{- site.Params.label.iconHeight | default "30" -}}">
+                {{- else }}
+                <img src="{{- site.Params.label.icon | absURL -}}" alt="" aria-label="logo"
+                    height="{{- site.Params.label.iconHeight | default "30" -}}">
+                {{- end -}}
+                {{- else if hasPrefix site.Params.label.iconSVG "<svg" }}
+                    {{ site.Params.label.iconSVG | safeHTML }}
+                {{- end -}}
+                {{- $label_text -}}
+            </a>
+            {{- end }}
+            <div class="logo-switches">
+                {{- if (not site.Params.disableThemeToggle) }}
+                <button id="theme-toggle" accesskey="t" title="(Alt + T)" aria-label="Toggle theme">
+                    <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
+                        fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                        stroke-linejoin="round">
+                        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                    </svg>
+                    <svg id="sun" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
+                        fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                        stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="5"></circle>
+                        <line x1="12" y1="1" x2="12" y2="3"></line>
+                        <line x1="12" y1="21" x2="12" y2="23"></line>
+                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                        <line x1="1" y1="12" x2="3" y2="12"></line>
+                        <line x1="21" y1="12" x2="23" y2="12"></line>
+                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                    </svg>
+                </button>
+                {{- end }}
+
+                {{- if (not site.Params.disableLangToggle) }}
+                    {{- $lang := .Lang}}
+                    {{- $separator := or $label_text (not site.Params.disableThemeToggle)}}
+                    {{- with site.Home.Translations }}
+                    <ul class="lang-switch">
+                        {{- if $separator }}<li>|</li>{{ end }}
+                        {{- range . -}}
+                        {{- if ne $lang .Lang }}
+                        <li>
+                            <a href="{{- .Permalink -}}" title="{{ .Language.Params.languageAltTitle | default (.Language.LanguageName | emojify) | default (.Lang | title) }}"
+                                aria-label="{{ .Language.LanguageName | default (.Lang | title) }}">
+                                {{- if (and site.Params.displayFullLangName (.Language.LanguageName)) }}
+                                {{- .Language.LanguageName | emojify -}}
+                                {{- else }}
+                                {{- .Lang | title -}}
+                                {{- end -}}
+                            </a>
+                        </li>
+                        {{- end -}}
+                        {{- end}}
+                    </ul>
+                    {{- end }}
+                {{- end }}
+            </div>
+        </div>
+        {{- $currentPage := . }}
+        <ul id="menu">
+            {{- range site.Menus.main }}
+            {{- $menu_item_url := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL) ) | absLangURL }}
+            {{- $page_url:= $currentPage.Permalink | absLangURL }}
+            {{- $is_search := eq (site.GetPage .KeyName).Layout `search` }}
+            <li>
+                <a href="{{ .URL | relLangURL }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
+                {{- cond $is_search (" accesskey=/" | safeHTMLAttr) ("" | safeHTMLAttr ) }}>
+                    <span {{- if eq $menu_item_url $page_url }} class="active" {{- end }}>
+                        {{- .Pre }}
+                        {{- .Name -}}
+                        {{ .Post -}}
+                    </span>
+                    {{- if (findRE "://" .URL) }}&nbsp;
+                    <svg fill="none" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round"
+                        stroke-linejoin="round" stroke-width="2.5" viewBox="0 0 24 24" height="12" width="12">
+                        <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path>
+                        <path d="M15 3h6v6"></path>
+                        <path d="M10 14L21 3"></path>
+                    </svg>
+                    {{- end }}
+                </a>
+            </li>
+            {{- end }}
+        </ul>
+    </nav>
+</header>


### PR DESCRIPTION
## Summary
- **Enable search page** — the Fuse.js search index (`index.json`) was being generated but no search page existed to use it. Adds `content/search.md` (`layout: search`) plus a `Search` menu entry, so `/search/` is built and reachable.
- **Fix nav links redirecting to production** — the PaperMod header rendered main-menu links with `absLangURL`, baking the full production host into every link. Viewed anywhere other than the live `baseURL` (local builds, preview servers), clicking a menu item bounced back to the production site. Overrides the header partial to use `relLangURL`, producing host-independent root-relative URLs (`/blog/posts/`), matching how breadcrumb/content links already behave.
- **Open search with `/` or `⌘K`/`Ctrl+K` from any page** — global keydown handler injected via PaperMod's `extend_footer` hook. `/` is ignored while typing in inputs; on the search page the shortcut just refocuses the input.
- **Content** — add "AI" to the profile subtitle focus areas.

## Notes
- The nav-link fix and search shortcut override/extend theme files via the repo's own `layouts/` (the theme is a submodule), so revisit them when bumping PaperMod.

## Verification
- Built with both production and localhost baseURLs; confirmed `public/search/index.html` is generated, menu links are root-relative with no hardcoded host, and the shortcut script is injected site-wide with a host-independent search URL.
- Live keypress behavior confirmed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)