### PR TITLE
Theme refresh: typography, code blocks, search pill, home tags

### DIFF
--- a/assets/css/extended/chroma.css
+++ b/assets/css/extended/chroma.css
@@ -1,0 +1,88 @@
+/* Generated using: hugo gen chromastyles --style=github-dark */
+
+/* Background */ .bg { color:#e6edf3;background-color:#0d1117; }
+/* PreWrapper */ .chroma { color:#e6edf3;background-color:#0d1117; }
+/* Other */ .chroma .x {  }
+/* Error */ .chroma .err { color:#f85149 }
+/* CodeLine */ .chroma .cl {  }
+/* LineLink */ .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+/* LineTable */ .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+/* LineHighlight */ .chroma .hl { background-color:#6e7681 }
+/* LineNumbersTable */ .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#737679 }
+/* LineNumbers */ .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#6e7681 }
+/* Line */ .chroma .line { display:flex; }
+/* Keyword */ .chroma .k { color:#ff7b72 }
+/* KeywordConstant */ .chroma .kc { color:#79c0ff }
+/* KeywordDeclaration */ .chroma .kd { color:#ff7b72 }
+/* KeywordNamespace */ .chroma .kn { color:#ff7b72 }
+/* KeywordPseudo */ .chroma .kp { color:#79c0ff }
+/* KeywordReserved */ .chroma .kr { color:#ff7b72 }
+/* KeywordType */ .chroma .kt { color:#ff7b72 }
+/* Name */ .chroma .n {  }
+/* NameAttribute */ .chroma .na {  }
+/* NameClass */ .chroma .nc { color:#f0883e;font-weight:bold }
+/* NameConstant */ .chroma .no { color:#79c0ff;font-weight:bold }
+/* NameDecorator */ .chroma .nd { color:#d2a8ff;font-weight:bold }
+/* NameEntity */ .chroma .ni { color:#ffa657 }
+/* NameException */ .chroma .ne { color:#f0883e;font-weight:bold }
+/* NameLabel */ .chroma .nl { color:#79c0ff;font-weight:bold }
+/* NameNamespace */ .chroma .nn { color:#ff7b72 }
+/* NameOther */ .chroma .nx {  }
+/* NameProperty */ .chroma .py { color:#79c0ff }
+/* NameTag */ .chroma .nt { color:#7ee787 }
+/* NameBuiltin */ .chroma .nb {  }
+/* NameBuiltinPseudo */ .chroma .bp {  }
+/* NameVariable */ .chroma .nv { color:#79c0ff }
+/* NameVariableClass */ .chroma .vc { color:#79c0ff }
+/* NameVariableGlobal */ .chroma .vg { color:#79c0ff }
+/* NameVariableInstance */ .chroma .vi { color:#79c0ff }
+/* NameVariableMagic */ .chroma .vm { color:#79c0ff }
+/* NameFunction */ .chroma .nf { color:#d2a8ff;font-weight:bold }
+/* NameFunctionMagic */ .chroma .fm { color:#d2a8ff;font-weight:bold }
+/* Literal */ .chroma .l { color:#a5d6ff }
+/* LiteralDate */ .chroma .ld { color:#79c0ff }
+/* LiteralString */ .chroma .s { color:#a5d6ff }
+/* LiteralStringAffix */ .chroma .sa { color:#79c0ff }
+/* LiteralStringBacktick */ .chroma .sb { color:#a5d6ff }
+/* LiteralStringChar */ .chroma .sc { color:#a5d6ff }
+/* LiteralStringDelimiter */ .chroma .dl { color:#79c0ff }
+/* LiteralStringDoc */ .chroma .sd { color:#a5d6ff }
+/* LiteralStringDouble */ .chroma .s2 { color:#a5d6ff }
+/* LiteralStringEscape */ .chroma .se { color:#79c0ff }
+/* LiteralStringHeredoc */ .chroma .sh { color:#79c0ff }
+/* LiteralStringInterpol */ .chroma .si { color:#a5d6ff }
+/* LiteralStringOther */ .chroma .sx { color:#a5d6ff }
+/* LiteralStringRegex */ .chroma .sr { color:#79c0ff }
+/* LiteralStringSingle */ .chroma .s1 { color:#a5d6ff }
+/* LiteralStringSymbol */ .chroma .ss { color:#a5d6ff }
+/* LiteralNumber */ .chroma .m { color:#a5d6ff }
+/* LiteralNumberBin */ .chroma .mb { color:#a5d6ff }
+/* LiteralNumberFloat */ .chroma .mf { color:#a5d6ff }
+/* LiteralNumberHex */ .chroma .mh { color:#a5d6ff }
+/* LiteralNumberInteger */ .chroma .mi { color:#a5d6ff }
+/* LiteralNumberIntegerLong */ .chroma .il { color:#a5d6ff }
+/* LiteralNumberOct */ .chroma .mo { color:#a5d6ff }
+/* Operator */ .chroma .o { color:#ff7b72;font-weight:bold }
+/* OperatorWord */ .chroma .ow { color:#ff7b72;font-weight:bold }
+/* Punctuation */ .chroma .p {  }
+/* Comment */ .chroma .c { color:#8b949e;font-style:italic }
+/* CommentHashbang */ .chroma .ch { color:#8b949e;font-style:italic }
+/* CommentMultiline */ .chroma .cm { color:#8b949e;font-style:italic }
+/* CommentSingle */ .chroma .c1 { color:#8b949e;font-style:italic }
+/* CommentSpecial */ .chroma .cs { color:#8b949e;font-weight:bold;font-style:italic }
+/* CommentPreproc */ .chroma .cp { color:#8b949e;font-weight:bold;font-style:italic }
+/* CommentPreprocFile */ .chroma .cpf { color:#8b949e;font-weight:bold;font-style:italic }
+/* Generic */ .chroma .g {  }
+/* GenericDeleted */ .chroma .gd { color:#ffa198;background-color:#490202 }
+/* GenericEmph */ .chroma .ge { font-style:italic }
+/* GenericError */ .chroma .gr { color:#ffa198 }
+/* GenericHeading */ .chroma .gh { color:#79c0ff;font-weight:bold }
+/* GenericInserted */ .chroma .gi { color:#56d364;background-color:#0f5323 }
+/* GenericOutput */ .chroma .go { color:#8b949e }
+/* GenericPrompt */ .chroma .gp { color:#8b949e }
+/* GenericStrong */ .chroma .gs { font-weight:bold }
+/* GenericSubheading */ .chroma .gu { color:#79c0ff }
+/* GenericTraceback */ .chroma .gt { color:#ff7b72 }
+/* GenericUnderline */ .chroma .gl { text-decoration:underline }
+/* TextWhitespace */ .chroma .w { color:#6e7681 }

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -495,6 +495,49 @@ code, pre, kbd, tt, .chroma {
   color: var(--accent);
 }
 
+/* ── Direction 4 · ⌘K search pill ── */
+
+.search-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 9px 5px 11px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--secondary);
+  background: var(--code-bg);
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.search-pill:hover {
+  border-color: var(--accent);
+  color: var(--primary);
+  background: var(--accent-dim);
+}
+
+.search-pill svg {
+  flex-shrink: 0;
+}
+
+.search-pill kbd {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--secondary);
+  background: var(--theme);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 6px;
+}
+
+/* Hide the keyboard hint on narrow screens */
+@media (max-width: 640px) {
+  .search-pill kbd {
+    display: none;
+  }
+}
+
 /* ── Direction 4 · Micro-interactions ── */
 
 html {

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -151,7 +151,7 @@
 .post-header::after {
   content: "";
   display: block;
-  width: 60px;
+  width: 120px;
   height: 3px;
   margin-top: 1.25rem;
   border-radius: 2px;
@@ -424,7 +424,7 @@ code, pre, kbd, tt, .chroma {
   padding: 1.1rem 1.15rem;
   border-radius: 0;
   background: transparent !important; /* wrapper provides the surface */
-  font-size: 0.98rem;
+  font-size: 1.1rem;
   line-height: 1.7;
 }
 

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -482,6 +482,19 @@ code, pre, kbd, tt, .chroma {
   border-color: var(--accent);
 }
 
+/* ── Header brand: "Brock's Blog" + accent period ── */
+
+.logo > a {
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.logo > a::after {
+  content: ".";
+  color: var(--accent);
+}
+
 /* ── Direction 4 · Micro-interactions ── */
 
 html {

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -35,7 +35,7 @@
 .profile + .recent-posts::before {
   content: "";
   display: block;
-  width: 60px;
+  width: 120px;
   height: 3px;
   margin: 0 auto 2.5rem;
   border-radius: 2px;
@@ -424,8 +424,8 @@ code, pre, kbd, tt, .chroma {
   padding: 1.1rem 1.15rem;
   border-radius: 0;
   background: transparent !important; /* wrapper provides the surface */
-  font-size: 0.88rem;
-  line-height: 1.65;
+  font-size: 0.98rem;
+  line-height: 1.7;
 }
 
 /* Language label, sourced from Hugo's data-lang attribute */

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -162,7 +162,7 @@
 .footer::before {
   content: "";
   display: block;
-  width: 60px;
+  width: 120px;
   height: 3px;
   margin: 0 auto 1.5rem;
   border-radius: 2px;

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -123,6 +123,35 @@
   opacity: 0.7;
 }
 
+/* Tags on home-page post entries */
+.entry-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.entry-tags li {
+  display: inline-flex;
+}
+
+.entry-tags a {
+  font-size: 0.72rem;
+  color: var(--secondary);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 10px;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.entry-tags a:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-dim);
+}
+
 /* ── Pagination ── */
 
 .pagination {

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -353,3 +353,168 @@
 .top-link:hover {
   color: var(--accent);
 }
+
+/* ════════════════════════════════════════════════════════════
+   THEME REFRESH — directions 2 (typography), 3 (code), 4 (micro)
+   ════════════════════════════════════════════════════════════ */
+
+:root {
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-display: "Sora", var(--font-body);
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ── Direction 2 · Typography ── */
+
+body {
+  font-family: var(--font-body);
+  font-size: 1.02rem;
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+h1, h2, h3, h4, h5, h6,
+.post-title, .entry-header h2, .page-header h1 {
+  font-family: var(--font-display);
+  letter-spacing: -0.02em;
+}
+
+.post-content {
+  font-size: 1.05rem;
+  line-height: 1.78;
+}
+
+.post-content p {
+  margin-bottom: 1.3em;
+}
+
+code, pre, kbd, tt, .chroma {
+  font-family: var(--font-mono);
+}
+
+/* Gradient-clipped profile name (one restrained accent moment) */
+.profile .profile_inner h1 {
+  font-family: var(--font-display);
+  background: linear-gradient(120deg, var(--primary) 35%, var(--accent));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* ── Direction 3 · Code blocks ── */
+
+.post-content .highlight {
+  position: relative;
+  margin: 1.5rem 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: #0d1117; /* matches the github-dark chroma surface */
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+
+.post-content .highlight:hover {
+  border-color: var(--accent-dim);
+}
+
+.post-content .highlight pre.chroma {
+  margin: 0;
+  padding: 1.1rem 1.15rem;
+  border-radius: 0;
+  background: transparent !important; /* wrapper provides the surface */
+  font-size: 0.88rem;
+  line-height: 1.65;
+}
+
+/* Language label, sourced from Hugo's data-lang attribute */
+.post-content .highlight code[data-lang]:not([data-lang=""])::before {
+  content: attr(data-lang);
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: var(--accent-dim);
+  border-left: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-bottom-left-radius: 8px;
+  padding: 3px 9px;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+/* On hover, fade the label so the copy button can own the corner */
+.post-content .highlight:hover code[data-lang]::before {
+  opacity: 0;
+}
+
+/* Blue text-selection inside code */
+.post-content .highlight ::selection {
+  background: var(--accent-dim);
+  color: #fff;
+}
+
+/* Inline code */
+.post-content :not(pre) > code {
+  font-size: 0.86em;
+  border-radius: 5px;
+}
+
+/* Copy button — match the accent system */
+.post-content .highlight .copy-code {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border);
+  color: var(--secondary);
+  border-radius: 6px;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.post-content .highlight .copy-code:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ── Direction 4 · Micro-interactions ── */
+
+html {
+  scroll-behavior: smooth;
+}
+
+/* Accent focus ring for keyboard users (pairs with search shortcuts) */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+.button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+/* Wipe-in underline for in-text links: faint rule always, accent on hover */
+.post-content a {
+  box-shadow: none;
+  background-image:
+    linear-gradient(var(--accent), var(--accent)),
+    linear-gradient(var(--accent-dim), var(--accent-dim));
+  background-size: 0% 2px, 100% 1px;
+  background-position: 0 100%, 0 100%;
+  background-repeat: no-repeat;
+  transition: background-size 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.post-content a:hover {
+  background-size: 100% 2px, 100% 1px;
+}

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -502,10 +502,10 @@ code, pre, kbd, tt, .chroma {
   align-items: center;
   gap: 8px;
   padding: 5px 9px 5px 11px;
-  border: 1px solid var(--border);
+  border: 1px solid rgba(128, 128, 128, 0.18);
   border-radius: 999px;
   color: var(--secondary);
-  background: var(--code-bg);
+  background: transparent;
   transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
 }
 

--- a/content/posts/2026/sync-data-with-lakebase-postgres/index.md
+++ b/content/posts/2026/sync-data-with-lakebase-postgres/index.md
@@ -3,9 +3,9 @@ title: "Sync Data With Lakebase Postgres"
 date: 2026-06-03T11:12:06-05:00
 draft: false
 tags:
-  - Databricks
-  - Lakebase
-  - Postgres
+  - databricks
+  - lakebase
+  - postgres
 ---
 
 An overview of how to get data into and out of Lakebase Postgres
@@ -220,6 +220,3 @@ CREATE FOREIGN CATALOG [IF NOT EXISTS] <catalog-name>
 USING CONNECTION <connection-name>
 OPTIONS (database '<database-name>');
 ```
-
----
-

--- a/hugo.toml
+++ b/hugo.toml
@@ -25,6 +25,12 @@ summaryLength = 30
   endLevel = 5
   ordered = false
 
+[markup.highlight]
+  noClasses = false
+  codeFences = true
+  guessSyntax = true
+  tabWidth = 2
+
 [params]
   defaultTheme = "dark"
   disableThemeToggle = false
@@ -37,6 +43,7 @@ summaryLength = 30
   ShowWordCount = true
   ShowRssButtonInSectionTermList = true
   ShowShareButtons = false
+  ShowCodeCopyButtons = true
   dateFormat = "2006-01-02"
   mainSections = ["posts"]
   author = "Brock B"

--- a/hugo.toml
+++ b/hugo.toml
@@ -48,6 +48,9 @@ summaryLength = 30
   mainSections = ["posts"]
   author = "Brock B"
 
+  [params.label]
+    text = "Brock's Blog"
+
   [params.assets]
     favicon = "/blog/favicon.svg"
     favicon16x16 = "/blog/favicon-16x16.png"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -40,6 +40,13 @@
       <span>{{ .Date.Format ($.Site.Params.dateFormat | default "2006-01-02") }}</span>
       {{- if $.Site.Params.ShowReadingTime }}&nbsp;·&nbsp;{{ .ReadingTime }} min{{ end }}
     </footer>
+    {{- with .Params.tags }}
+    <ul class="entry-tags">
+      {{- range . }}
+      <li><a href="{{ (printf "tags/%s/" (. | urlize)) | relLangURL }}">{{ . }}</a></li>
+      {{- end }}
+    </ul>
+    {{- end }}
   </article>
   {{- end }}
   {{- if gt $paginator.TotalPages 1 }}

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -23,6 +23,13 @@
         }
     }
 
+    // Show the right hint in the nav search pill (⌘K on mac, Ctrl K elsewhere)
+    if (!/Mac|iPhone|iPad/.test(navigator.platform)) {
+        document.querySelectorAll(".search-pill kbd").forEach(function (k) {
+            k.textContent = "Ctrl K";
+        });
+    }
+
     document.addEventListener("keydown", function (e) {
         // Cmd+K (mac) / Ctrl+K (others)
         if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,0 +1,7 @@
+{{- /* Web fonts: Inter (body), Sora (display/headings), JetBrains Mono (code). */ -}}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preload" as="style"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Sora:wght@600;700;800&display=swap">
+<link rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Sora:wght@600;700;800&display=swap">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -87,8 +87,17 @@
             {{- $page_url:= $currentPage.Permalink | absLangURL }}
             {{- $is_search := eq (site.GetPage .KeyName).Layout `search` }}
             <li>
-                <a href="{{ .URL | relLangURL }}" title="{{ .Title | default .Name }} {{- cond $is_search (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr ) }}"
-                {{- cond $is_search (" accesskey=/" | safeHTMLAttr) ("" | safeHTMLAttr ) }}>
+                {{- if $is_search }}
+                <a href="{{ .URL | relLangURL }}" class="search-pill" accesskey="/" title="Search (⌘K or /)">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" height="15" width="15">
+                        <circle cx="11" cy="11" r="8"></circle>
+                        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                    </svg>
+                    <span>{{ .Name }}</span>
+                    <kbd>⌘K</kbd>
+                </a>
+                {{- else }}
+                <a href="{{ .URL | relLangURL }}" title="{{ .Title | default .Name }}">
                     <span {{- if eq $menu_item_url $page_url }} class="active" {{- end }}>
                         {{- .Pre }}
                         {{- .Name -}}
@@ -103,6 +112,7 @@
                     </svg>
                     {{- end }}
                 </a>
+                {{- end }}
             </li>
             {{- end }}
         </ul>


### PR DESCRIPTION
## Summary
A sleek, subtle blue-on-black refresh building on the existing accent system. **Note:** this branch merges in the search work from #41, so it supersedes that PR — merging this lands both. (Close #41 in favor of this, or merge #41 first and let this fast-forward past it.)

### Typography
- Load Sora (display) + Inter (body) + JetBrains Mono (code) via `extend_head`
- Larger reading measure / line-height; gradient-clipped profile name
- Header brand set to "Brock's Blog." with a blue accent period

### Code blocks
- Class-based highlighting (`noClasses=false`) with a bundled github-dark Chroma theme (near-black surface)
- Framed blocks with a language label (from `data-lang`), blue text-selection, copy buttons styled to the accent
- Larger code font for readability

### Search (from #41) + ⌘K pill
- Search page (`content/search.md`) + JSON index, host-independent nav links
- Global `/` and ⌘K/Ctrl+K shortcuts open search from any page
- Nav search pill with a platform-aware keyboard hint, styled subtly (no fill, hairline border)

### Micro-interactions
- Accent `:focus-visible` rings, smooth scroll, wipe-in link underlines

### Home page
- Tags shown as subtle chips on each post entry, linking to tag pages
- Accent dividers (profile / post-title / footer) lengthened to 120px

## Notes
- Several theme files are overridden in the repo's own `layouts/` (PaperMod is a submodule), so revisit when bumping the theme.
- Web fonts load from Google Fonts.

## Verification
- Built repeatedly; confirmed class-based code highlighting, language labels, copy buttons, pill markup + host-independent URLs, tag links, font loading, and all accent/divider rules in the bundled stylesheet. Visual changes confirmed live via `make serve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)