### PR TITLE
Add line continuation to ipython REPL command

### DIFF
--- a/content/posts/2026/useful-stuff.md
+++ b/content/posts/2026/useful-stuff.md
@@ -38,7 +38,8 @@ source.close()
 Quickly start a Python REPL in `ipython` with vim keybinds
 
 ```shell
-uv venv && source .venv/bin/activate && uv pip install ipython && ipython --TerminalInteractiveShell.editing_mode=vi --colors="Linux"
+uv venv && source .venv/bin/activate && uv pip install ipython && \
+  ipython --TerminalInteractiveShell.editing_mode=vi --colors="Linux"
 ```
 
 `#python`


### PR DESCRIPTION
## Summary
- Format the `ipython` vim-keybind REPL one-liner in the 2026 useful-stuff post with a line continuation so it wraps cleanly instead of overflowing.

## Test Plan
- [x] Reviewed rendered diff — content-only formatting change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)