### PR TITLE
feat: exit search back to home with Escape or Cmd/Ctrl+K

### DIFF
--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -1,8 +1,10 @@
-{{- /* Global keyboard shortcut: open search with "/" or Cmd/Ctrl+K from any page. */ -}}
+{{- /* Global keyboard shortcut: open search with "/" or Cmd/Ctrl+K from any page.
+       While on the search page, Escape or Cmd/Ctrl+K exits back to the home page. */ -}}
 {{- with site.GetPage "/search" }}
 <script>
 (function () {
     var searchURL = {{ .RelPermalink }};
+    var homeURL = {{ site.Home.RelPermalink }};
 
     function isEditable(el) {
         if (!el) return false;
@@ -23,6 +25,10 @@
         }
     }
 
+    function exitSearch() {
+        window.location.href = homeURL;
+    }
+
     // Show the right hint in the nav search pill (⌘K on mac, Ctrl K elsewhere)
     if (!/Mac|iPhone|iPad/.test(navigator.platform)) {
         document.querySelectorAll(".search-pill kbd").forEach(function (k) {
@@ -31,10 +37,20 @@
     }
 
     document.addEventListener("keydown", function (e) {
-        // Cmd+K (mac) / Ctrl+K (others)
+        // Cmd+K (mac) / Ctrl+K (others) — toggles: opens search, or exits to home when already searching
         if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
             e.preventDefault();
-            openSearch();
+            if (onSearchPage()) {
+                exitSearch();
+            } else {
+                openSearch();
+            }
+            return;
+        }
+        // Escape — exit search back to home
+        if (e.key === "Escape" && onSearchPage()) {
+            e.preventDefault();
+            exitSearch();
             return;
         }
         // "/" — but not while typing in a field, and not with modifiers


### PR DESCRIPTION
## Summary
Enhances the search UX so users can quickly get out of search:

- **Escape** while on the search page → navigates back to the site home.
- **Cmd/Ctrl+K** is now a toggle: opens search from any page, and exits back to home when already on the search page (previously it just re-focused the input).
- `/` still opens search, and Escape stays inert off the search page.

Home target uses `site.Home.RelPermalink`, so it respects the site's `/blog/` base path rather than a hardcoded `/`.

All logic lives in `layouts/partials/extend_footer.html` (the existing global keyboard-shortcut partial).

## Testing
Verified in a real browser (Playwright against `hugo server`):

- ✅ Cmd/Ctrl+K from home → search page, input autofocused
- ✅ Escape on search → home
- ✅ Clicked nav search icon → search
- ✅ Cmd/Ctrl+K on search → home (toggle off)
- 🔍 Escape with text typed in the box still exits (doesn't just clear)
- 🔍 Escape on home is a no-op
- 🔍 `/` on home still opens search

🤖 Generated with [Claude Code](https://claude.com/claude-code)