### PR TITLE
Make ⌘K search a dismissable overlay

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -603,3 +603,141 @@ input:focus-visible,
 .post-content a:hover {
   background-size: 100% 2px, 100% 1px;
 }
+
+/* ── ⌘K command-palette search overlay ── */
+
+.cmdk {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: none;
+}
+
+.cmdk.cmdk-open {
+  display: block;
+}
+
+body.cmdk-lock {
+  overflow: hidden;
+}
+
+.cmdk-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.cmdk-panel {
+  position: relative;
+  width: min(90vw, 600px);
+  margin: 12vh auto 0;
+  background: var(--entry);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  animation: cmdk-in 0.14s ease-out;
+}
+
+@keyframes cmdk-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.cmdk-inputwrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cmdk-icon {
+  flex-shrink: 0;
+  color: var(--secondary);
+}
+
+.cmdk-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--primary);
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.cmdk-input::placeholder {
+  color: var(--secondary);
+}
+
+.cmdk-esc {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--secondary);
+  background: var(--theme);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 6px;
+}
+
+.cmdk-results {
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  max-height: min(50vh, 380px);
+  overflow-y: auto;
+}
+
+.cmdk-result a {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 9px 11px;
+  border-radius: 8px;
+  text-decoration: none;
+  box-shadow: none;
+  background: none;
+}
+
+.cmdk-result.active a {
+  background: var(--accent-dim);
+}
+
+.cmdk-result-title {
+  color: var(--primary);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.cmdk-result.active .cmdk-result-title {
+  color: var(--accent);
+}
+
+.cmdk-result-summary {
+  color: var(--secondary);
+  font-size: 0.82rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cmdk-empty {
+  margin: 0;
+  padding: 16px;
+  text-align: center;
+  color: var(--secondary);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+  .cmdk-panel {
+    margin-top: 8vh;
+    width: 94vw;
+  }
+  .cmdk-esc {
+    display: none;
+  }
+}

--- a/assets/js/cmdk-search.js
+++ b/assets/js/cmdk-search.js
@@ -1,0 +1,234 @@
+/* ⌘K / "/" command-palette search overlay.
+ * Progressive enhancement over the /search page: opens a dismissable modal on
+ * top of the current page, lazy-loads the Fuse index on first use, and can be
+ * closed with Escape, a click on the backdrop, or ⌘K/Ctrl+K again.
+ * Depends on the global `Fuse` (bundled ahead of this file). */
+(function () {
+  "use strict";
+
+  var root = document.getElementById("cmdk");
+  if (!root || typeof Fuse === "undefined") return;
+
+  var backdrop = root.querySelector(".cmdk-backdrop");
+  var input = root.querySelector(".cmdk-input");
+  var resultsEl = root.querySelector(".cmdk-results");
+  var emptyEl = root.querySelector(".cmdk-empty");
+  var jsonURL = root.getAttribute("data-index");
+  var searchURL = root.getAttribute("data-search-url");
+
+  var fuse = null; // built on first open
+  var loading = false;
+  var lastFocused = null; // element to restore focus to on close
+  var activeIndex = -1; // highlighted result
+  var results = [];
+
+  var isMac = /Mac|iPhone|iPad/.test(navigator.platform);
+
+  function isEditable(el) {
+    if (!el) return false;
+    var tag = el.tagName;
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
+  }
+
+  function isOpen() {
+    return root.classList.contains("cmdk-open");
+  }
+
+  function loadIndex() {
+    if (fuse || loading) return;
+    loading = true;
+    emptyEl.textContent = "Loading search…";
+    emptyEl.hidden = false;
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", jsonURL);
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState !== 4) return;
+      loading = false;
+      if (xhr.status === 200) {
+        try {
+          var data = JSON.parse(xhr.responseText);
+          fuse = new Fuse(data, {
+            distance: 100,
+            threshold: 0.4,
+            ignoreLocation: true,
+            keys: ["title", "permalink", "summary", "content"],
+          });
+          if (input.value) render(input.value);
+          else emptyEl.hidden = true;
+        } catch (err) {
+          emptyEl.textContent = "Search unavailable.";
+        }
+      } else {
+        emptyEl.textContent = "Search unavailable.";
+      }
+    };
+    xhr.send();
+  }
+
+  function render(query) {
+    query = (query || "").trim();
+    resultsEl.innerHTML = "";
+    activeIndex = -1;
+    results = [];
+
+    if (!query) {
+      emptyEl.hidden = true;
+      return;
+    }
+    if (!fuse) {
+      // index still loading; loadIndex() will re-render when ready
+      return;
+    }
+
+    results = fuse.search(query).slice(0, 8);
+    if (!results.length) {
+      emptyEl.textContent = "No results for “" + query + "”";
+      emptyEl.hidden = false;
+      return;
+    }
+    emptyEl.hidden = true;
+
+    var frag = document.createDocumentFragment();
+    results.forEach(function (r, i) {
+      var item = r.item;
+      var li = document.createElement("li");
+      li.className = "cmdk-result";
+      li.id = "cmdk-result-" + i;
+      li.setAttribute("role", "option");
+      li.setAttribute("aria-selected", "false");
+
+      var a = document.createElement("a");
+      a.href = item.permalink;
+      a.tabIndex = -1;
+
+      var title = document.createElement("span");
+      title.className = "cmdk-result-title";
+      title.textContent = item.title || item.permalink;
+      a.appendChild(title);
+
+      if (item.summary) {
+        var summary = document.createElement("span");
+        summary.className = "cmdk-result-summary";
+        summary.textContent = item.summary;
+        a.appendChild(summary);
+      }
+
+      li.appendChild(a);
+      li.addEventListener("mousemove", function () {
+        setActive(i);
+      });
+      li.addEventListener("click", function () {
+        go(i);
+      });
+      frag.appendChild(li);
+    });
+    resultsEl.appendChild(frag);
+    setActive(0);
+  }
+
+  function setActive(i) {
+    var items = resultsEl.children;
+    if (activeIndex >= 0 && items[activeIndex]) {
+      items[activeIndex].classList.remove("active");
+      items[activeIndex].setAttribute("aria-selected", "false");
+    }
+    activeIndex = i;
+    if (i >= 0 && items[i]) {
+      items[i].classList.add("active");
+      items[i].setAttribute("aria-selected", "true");
+      input.setAttribute("aria-activedescendant", items[i].id);
+      items[i].scrollIntoView({ block: "nearest" });
+    } else {
+      input.removeAttribute("aria-activedescendant");
+    }
+  }
+
+  function move(delta) {
+    if (!results.length) return;
+    var next = activeIndex + delta;
+    if (next < 0) next = results.length - 1;
+    if (next >= results.length) next = 0;
+    setActive(next);
+  }
+
+  function go(i) {
+    if (i >= 0 && results[i]) {
+      window.location.href = results[i].item.permalink;
+    } else if (input.value.trim() && searchURL) {
+      // Nothing highlighted: fall back to the full search page.
+      window.location.href = searchURL + "?query=" + encodeURIComponent(input.value.trim());
+    }
+  }
+
+  function open() {
+    if (isOpen()) return;
+    lastFocused = document.activeElement;
+    root.classList.add("cmdk-open");
+    root.setAttribute("aria-hidden", "false");
+    document.body.classList.add("cmdk-lock");
+    loadIndex();
+    input.focus();
+    input.select();
+  }
+
+  function close() {
+    if (!isOpen()) return;
+    root.classList.remove("cmdk-open");
+    root.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("cmdk-lock");
+    if (lastFocused && typeof lastFocused.focus === "function") lastFocused.focus();
+  }
+
+  function toggle() {
+    if (isOpen()) close();
+    else open();
+  }
+
+  // Backdrop click closes; clicks inside the panel do not (they don't reach here).
+  backdrop.addEventListener("click", close);
+
+  input.addEventListener("input", function () {
+    render(input.value);
+  });
+
+  input.addEventListener("keydown", function (e) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      move(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      move(-1);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      go(activeIndex);
+    }
+  });
+
+  // Global shortcuts.
+  document.addEventListener("keydown", function (e) {
+    // ⌘K (mac) / Ctrl+K (others) toggles the overlay.
+    if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      toggle();
+      return;
+    }
+    // Escape closes when open.
+    if (e.key === "Escape" && isOpen()) {
+      e.preventDefault();
+      close();
+      return;
+    }
+    // "/" opens — but not while typing in a field and not with modifiers.
+    if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey && !isEditable(e.target) && !isOpen()) {
+      e.preventDefault();
+      open();
+    }
+  });
+
+  // Reflect the platform in the nav pill hint (⌘K vs Ctrl K).
+  if (!isMac) {
+    document.querySelectorAll(".search-pill kbd").forEach(function (k) {
+      k.textContent = "Ctrl K";
+    });
+  }
+})();

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -1,48 +1,31 @@
-{{- /* Global keyboard shortcut: open search with "/" or Cmd/Ctrl+K from any page. */ -}}
+{{- /* ⌘K / "/" command-palette search overlay, available on every page.
+       Progressive enhancement over the /search page (which remains the no-JS
+       fallback and the nav-pill destination). */ -}}
 {{- with site.GetPage "/search" }}
-<script>
-(function () {
-    var searchURL = {{ .RelPermalink }};
+{{- $indexURL := "index.json" | relLangURL }}
+<div id="cmdk" class="cmdk" role="dialog" aria-modal="true" aria-label="Search"
+     aria-hidden="true" data-index="{{ $indexURL }}" data-search-url="{{ .RelPermalink }}">
+  <div class="cmdk-backdrop"></div>
+  <div class="cmdk-panel" role="document">
+    <div class="cmdk-inputwrap">
+      <svg class="cmdk-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+           stroke-linecap="round" stroke-linejoin="round" width="18" height="18" aria-hidden="true">
+        <circle cx="11" cy="11" r="8"></circle>
+        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+      </svg>
+      <input class="cmdk-input" type="search" role="combobox" aria-expanded="true"
+             aria-controls="cmdk-results" aria-autocomplete="list" autocomplete="off"
+             spellcheck="false" maxlength="64" placeholder="Search posts…" aria-label="Search posts">
+      <kbd class="cmdk-esc">Esc</kbd>
+    </div>
+    <ul id="cmdk-results" class="cmdk-results" role="listbox" aria-label="Search results"></ul>
+    <p class="cmdk-empty" hidden></p>
+  </div>
+</div>
 
-    function isEditable(el) {
-        if (!el) return false;
-        var tag = el.tagName;
-        return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
-    }
-
-    function onSearchPage() {
-        return window.location.pathname.replace(/\/+$/, "") === searchURL.replace(/\/+$/, "");
-    }
-
-    function openSearch() {
-        if (onSearchPage()) {
-            var input = document.getElementById("searchInput");
-            if (input) input.focus();
-        } else {
-            window.location.href = searchURL;
-        }
-    }
-
-    // Show the right hint in the nav search pill (⌘K on mac, Ctrl K elsewhere)
-    if (!/Mac|iPhone|iPad/.test(navigator.platform)) {
-        document.querySelectorAll(".search-pill kbd").forEach(function (k) {
-            k.textContent = "Ctrl K";
-        });
-    }
-
-    document.addEventListener("keydown", function (e) {
-        // Cmd+K (mac) / Ctrl+K (others)
-        if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
-            e.preventDefault();
-            openSearch();
-            return;
-        }
-        // "/" — but not while typing in a field, and not with modifiers
-        if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey && !isEditable(e.target)) {
-            e.preventDefault();
-            openSearch();
-        }
-    });
-})();
-</script>
+{{- $fuse := resources.Get "js/fuse.basic.min.js" }}
+{{- $cmdk := resources.Get "js/cmdk-search.js" }}
+{{- $bundle := slice $fuse $cmdk | resources.Concat "assets/js/cmdk-bundle.js" }}
+{{- if hugo.IsProduction }}{{ $bundle = $bundle | minify | fingerprint }}{{ end }}
+<script src="{{ $bundle.RelPermalink }}" defer></script>
 {{- end }}


### PR DESCRIPTION
## Problem

Pressing ⌘K didn't open a dismissable UI — `extend_footer.html` did a **hard browser navigation** to the `/search` page. Because nothing floating ever opened, Escape, clicking away, and a second ⌘K had nothing to close.

## Fix

Replace the navigation shortcut with a **command-palette overlay** that opens on top of the current page:

- **⌘K / Ctrl+K** toggles it open/closed
- **Escape** closes it
- **Click on the backdrop** closes it
- **`/`** opens it (unless typing in a field)

The overlay lazy-loads the Fuse index on first open, renders live results with **arrow-key navigation** + Enter, locks body scroll while open, and restores focus on close. The `/search` page remains the no-JS fallback and the nav-pill destination.

## Changes

- `assets/js/cmdk-search.js` (new) — overlay logic
- `layouts/partials/extend_footer.html` — render overlay markup + bundle `fuse` with the overlay JS (minified/fingerprinted in prod)
- `assets/css/extended/custom.css` — theme-aware overlay styling using existing PaperMod vars

## Verification

- `hugo` build passes; overlay markup + bundle present in output; `index.json` populated
- Bundled JS carries global `Fuse` + overlay logic; syntax valid
- Node harness loading the real overlay code against a stubbed DOM: **12/12 assertions pass** — ⌘K opens, ⌘K-again closes, Escape closes, backdrop-click closes, `/` opens, plus `aria-hidden` and body scroll-lock toggling

**Not yet done:** visual confirmation of results rendering/styling in a real browser (Chrome automation was unavailable). Reviewer sanity check: `hugo server`, ⌘K, type a query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)