### PR TITLE
Add 2026-08 useful stuff: pgcli + Lakebase Postgres

### DIFF
--- a/content/posts/2026/useful-stuff.md
+++ b/content/posts/2026/useful-stuff.md
@@ -86,3 +86,16 @@ test: ## test the logger
 ```
 
 `#Makefile`
+
+### 2026-08
+
+Use `pgcli` to connect to Lakebase Postgres using a `Makefile` target run via: `make lakebase/pgcli`
+
+```shell
+.PHONY: lakebase/pgcli
+lakebase/pgcli: ## start the lakebase pgcli shell 🐘
+	PGPASSWORD=$$(databricks database generate-database-credential --request-id "$$(uuidgen)" --json '{"instance_names": ["yourinstanceHere"]}' | jq -r .token) \
+		pgcli "postgresql://yourEmail%40gmail.com@name.database.us-east-2.cloud.databricks.com/databricks_postgres?sslmode=require"
+```
+
+`#postgres`

--- a/content/posts/2026/useful-stuff.md
+++ b/content/posts/2026/useful-stuff.md
@@ -98,4 +98,11 @@ lakebase/pgcli: ## start the lakebase pgcli shell 🐘
 		pgcli "postgresql://yourEmail%40gmail.com@name.database.us-east-2.cloud.databricks.com/databricks_postgres?sslmode=require"
 ```
 
+Run a script in `pgcli`:
+
+```
+\i /path/to/script.sql
+```
+
 `#postgres`
+


### PR DESCRIPTION
## Summary

Adds a `2026-08` section to `content/posts/2026/useful-stuff.md`:

- A `Makefile` target (`make lakebase/pgcli`) for starting a `pgcli` shell against Lakebase Postgres, generating the credential via the Databricks CLI.
- A note on running a SQL script from within `pgcli` (`\i /path/to/script.sql`).

Tagged `#postgres`.

## Test plan

Content-only change to a Hugo markdown post — no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)