### PR TITLE
Publish Spark Streaming templatized (take 2)

### DIFF
--- a/content/posts/2026/spark-streaming-templatized-take-2/index.md
+++ b/content/posts/2026/spark-streaming-templatized-take-2/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Spark Streaming - Templatized (Take 2)"
 date: 2026-08-24T22:37:08-05:00
-draft: true
+draft: false
 tags:
   - spark
   - streaming


### PR DESCRIPTION
Flips `draft: true` → `draft: false` on `content/posts/2026/spark-streaming-templatized-take-2/index.md` so the post renders in production builds.

Verified with a plain `hugo` build (no `--buildDrafts`): the page is emitted at `posts/2026/spark-streaming-templatized-take-2/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTJ9kD8MEmt4rWs7PULrr2